### PR TITLE
fix: allow slash in scope

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31104,7 +31104,7 @@ function isValidTitle(title) {
     const { type } = conventionalCommitsParser.sync(title, {
         mergePattern: /^Merge pull request #(\d+) from (.*)$/,
         mergeCorrespondence: ['id', 'source'],
-        headerPattern: /^(\w*)(?:\(([\w$.\-*, ]*)\))?: (.*)$/
+        headerPattern: /^(\w*)(?:\(([\w$.\-*,/ ]*)\))?: (.*)$/
     });
     if (!type) {
         const firstWord = title.split(' ')[0];

--- a/src/validate-title.test.ts
+++ b/src/validate-title.test.ts
@@ -80,4 +80,16 @@ describe('is-valid-title', () => {
     assert.isFalse(valid)
     assert.equal(type, null)
   })
+
+  it('allows comma in scope', () => {
+    const { valid, type } = validateTitle('fix(thing1,thing2): a bug')
+    assert.isTrue(valid)
+    assert.equal(type, 'fix')
+  })
+
+  it('allows slash in scope', () => {
+    const { valid, type } = validateTitle('fix(path/thing1,path/thing2): a bug')
+    assert.isTrue(valid)
+    assert.equal(type, 'fix')
+  })
 })

--- a/src/validate-title.ts
+++ b/src/validate-title.ts
@@ -14,8 +14,8 @@ export default function isValidTitle(title: string): ValidTitle {
     mergePattern: /^Merge pull request #(\d+) from (.*)$/,
     mergeCorrespondence: ['id', 'source'],
 
-    // allow comma in scope
-    headerPattern: /^(\w*)(?:\(([\w$.\-*, ]*)\))?: (.*)$/
+    // allow comma and slash in scope
+    headerPattern: /^(\w*)(?:\(([\w$.\-*,/ ]*)\))?: (.*)$/
   })
 
   // we allow merge, refactor, and release commits as


### PR DESCRIPTION
allows `feat(checks/check-id, rule/rule-id)` type commits